### PR TITLE
Various fixes around reading db conf from pgpass

### DIFF
--- a/akagi/data_sources/redshift_data_source.py
+++ b/akagi/data_sources/redshift_data_source.py
@@ -111,11 +111,15 @@ class RedshiftDataSource(DataSource):
             # Load .pgpass file
             if os.path.isfile(pgpass_path):
                 with open(pgpass_path) as f:
-                    args = [s.strip() for s in f.read().split(':')]
-
+                    lines = f.read().split('\n')
+                    assert len(lines) > 0, 'Empty .pgpass file'
+                    args = [s.strip() for s in lines[0].split(':')]
                     assert len(args) == 5, 'Invalid format .pgpass. Expected `hostname:port:database:username:password`'
-                    self.__pgpass['db_host'], self.__pgpass['db_port'], self.__pgpass['db_name'], \
-                        self.__pgpass['db_user'], self.__pgpass['db_pass'] = args
+                    self.__pgpass['db_host'] = args[0]
+                    self.__pgpass['db_port'] = args[1] if args[1] != "*" else ''
+                    self.__pgpass['db_name'] = args[2] if args[2] != "*" else ''
+                    self.__pgpass['db_user'] = args[3]
+                    self.__pgpass['db_pass'] = args[4]
 
         return self.__pgpass
 


### PR DESCRIPTION
## Problem

I didn't pass dbconfig dictionary when I was trying to read data from the Redshift database. As a result,  `RedshiftDataSource` tried to fallback on reading the configuration from .pgpass file but it had a couple of problems with it.

1. `RedshiftDataSource` assumes that .pgconf has only one line of configuration. If there is more:
```args = [s.strip() for s in f.read().split(':')]``` will return some multiplication of 5 (in my case 25) and the script will quit failing the assertion that the number of fields in .pgpass is invalid
2. Script will read the wildcard (*) expression as it is and the psycopg will fail with:
`psycopg2.OperationalError: invalid port number: "*"`

After fixing those two issues, I was able to get the data from Redshift using the .pgpass. 

## Solution

1. For the first problem, I'm doing an additional split to get the lines in the separate elements in the list. This is problably the laziest solution possible and might not be what you want. Some more sophisticated solution would be to pass the username or some other field to the `RedshiftDataSource` constructor and try to match the appropriate line based on this username

2. For the second one, I'm defaulting the database name and port to empty string in case it appears as a wildcard in the pgpass.